### PR TITLE
Add back support for Livewire v1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": "^7.2|^8.0",
         "illuminate/support": "^7.0|^8.0",
-        "livewire/livewire": "^2.0"
+        "livewire/livewire": "^1.0|^2.0"
     },
     "require-dev": {
         "orchestra/testbench": "^5.0|^6.0",


### PR DESCRIPTION
Is there a reason Livewire v1 support was dropped? This package seems to work just fine with Livewire v1.

Would be great to keep support for Livewire v1 until something only available in v2 needs to be used.

Would also make upgrading our app to Laravel v8 a lot easier.

Love,

Wilbur.